### PR TITLE
ENG-TASK-45: toggle bug fix

### DIFF
--- a/yank_extension/manifest.json
+++ b/yank_extension/manifest.json
@@ -34,5 +34,5 @@
 			"resources": ["assets/*"]
 		}
 	],
-	"permissions": ["bookmarks"]
+	"permissions": ["bookmarks", "storage"]
 }

--- a/yank_extension/package-lock.json
+++ b/yank_extension/package-lock.json
@@ -11,6 +11,7 @@
 				"@radix-ui/react-dialog": "^1.1.1",
 				"@radix-ui/react-popover": "^1.1.1",
 				"@radix-ui/react-slot": "^1.1.0",
+				"@radix-ui/react-switch": "^1.1.1",
 				"@supabase/supabase-js": "^2.45.4",
 				"axios": "^1.7.7",
 				"class-variance-authority": "^0.7.0",
@@ -1577,6 +1578,48 @@
 				}
 			}
 		},
+		"node_modules/@radix-ui/react-switch": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.1.1.tgz",
+			"integrity": "sha512-diPqDDoBcZPSicYoMWdWx+bCPuTRH4QSp9J+65IvtdS0Kuzt67bI6n32vCj8q6NZmYW/ah+2orOtMwcX5eQwIg==",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.0",
+				"@radix-ui/react-compose-refs": "1.1.0",
+				"@radix-ui/react-context": "1.1.1",
+				"@radix-ui/react-primitive": "2.0.0",
+				"@radix-ui/react-use-controllable-state": "1.1.0",
+				"@radix-ui/react-use-previous": "1.1.0",
+				"@radix-ui/react-use-size": "1.1.0"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-context": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+			"integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@radix-ui/react-use-callback-ref": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
@@ -1629,6 +1672,20 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
 			"integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-previous": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz",
+			"integrity": "sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==",
 			"peerDependencies": {
 				"@types/react": "*",
 				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -7685,6 +7742,28 @@
 				"@radix-ui/react-compose-refs": "1.1.0"
 			}
 		},
+		"@radix-ui/react-switch": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.1.1.tgz",
+			"integrity": "sha512-diPqDDoBcZPSicYoMWdWx+bCPuTRH4QSp9J+65IvtdS0Kuzt67bI6n32vCj8q6NZmYW/ah+2orOtMwcX5eQwIg==",
+			"requires": {
+				"@radix-ui/primitive": "1.1.0",
+				"@radix-ui/react-compose-refs": "1.1.0",
+				"@radix-ui/react-context": "1.1.1",
+				"@radix-ui/react-primitive": "2.0.0",
+				"@radix-ui/react-use-controllable-state": "1.1.0",
+				"@radix-ui/react-use-previous": "1.1.0",
+				"@radix-ui/react-use-size": "1.1.0"
+			},
+			"dependencies": {
+				"@radix-ui/react-context": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+					"integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+					"requires": {}
+				}
+			}
+		},
 		"@radix-ui/react-use-callback-ref": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
@@ -7711,6 +7790,12 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
 			"integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+			"requires": {}
+		},
+		"@radix-ui/react-use-previous": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz",
+			"integrity": "sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==",
 			"requires": {}
 		},
 		"@radix-ui/react-use-rect": {

--- a/yank_extension/package.json
+++ b/yank_extension/package.json
@@ -16,6 +16,7 @@
 		"@radix-ui/react-dialog": "^1.1.1",
 		"@radix-ui/react-popover": "^1.1.1",
 		"@radix-ui/react-slot": "^1.1.0",
+		"@radix-ui/react-switch": "^1.1.1",
 		"@supabase/supabase-js": "^2.45.4",
 		"axios": "^1.7.7",
 		"class-variance-authority": "^0.7.0",

--- a/yank_extension/src/App.tsx
+++ b/yank_extension/src/App.tsx
@@ -1,46 +1,39 @@
 import "./App.css";
 import "./index.css";
 import Home from "./Mycomponents/Home";
-import supabase from "./api/supabaseClient";
-import { useEffect, useState } from "react";
-
-interface Flashcard {
-	id: number;
-	created_at?: number;
-	content?: string;
-}
+import { Switch } from "@/components/ui/switch";
+import { useState, useEffect } from "react";
 
 function App() {
-	const [fetchError, setFetchError] = useState<string | null>("");
+	const [isHighlighterEnabled, setIsHighlighterEnabled] = useState<
+		boolean | undefined
+	>(undefined);
 
-	const [flashcards, setFlashcards] = useState<Flashcard[]>([]);
+	type Checked = boolean;
+	const handleCheckedChange = (checked: Checked) => {
+		setIsHighlighterEnabled(checked);
+		chrome.runtime.sendMessage({
+			action: "toggleHighlighter",
+			data: checked,
+		});
+	};
+
 	useEffect(() => {
-		const fetchFlashcards = async () => {
-			const { data, error } = await supabase.from("Flashcards").select();
-
-			if (error) {
-				setFetchError("Could not fetch Flashcards");
-				console.log(error);
-				setFlashcards([]);
-			}
-			if (data) {
-				setFlashcards(data);
-				setFetchError(null);
-			}
-		};
-		fetchFlashcards();
+		chrome.storage.sync.get("isHighlighterEnabled", (result) => {
+			const isEnabled = result.isHighlighterEnabled ?? false;
+			setIsHighlighterEnabled(isEnabled);
+		});
 	}, []);
+
 	return (
 		<>
 			<div className="container mx-auto flex h-[360px] w-[360px] items-center justify-center rounded-lg">
-				{fetchError && <p>{fetchError}</p>}
-				{flashcards && (
-					<div>
-						{flashcards.map((flashcard) => (
-							<p>{flashcard.content}</p>
-						))}
-					</div>
-				)}
+				<div className="absolute right-2 top-2">
+					<Switch
+						checked={isHighlighterEnabled}
+						onCheckedChange={handleCheckedChange}
+					/>
+				</div>
 				<Home />
 			</div>
 		</>

--- a/yank_extension/src/Mycomponents/Home.tsx
+++ b/yank_extension/src/Mycomponents/Home.tsx
@@ -3,14 +3,14 @@ import EditablePreview from "./EditablePreview.tsx";
 import { Tags } from "./tags.tsx";
 import { Button } from "@/components/ui/button";
 import React, { useEffect, useState } from "react";
-import api from "../api/axiosConfig.ts";
-import axios, { AxiosError } from "axios";
+// import api from "../api/axiosConfig.ts";
+// import axios, { AxiosError } from "axios";
 
 const Home: React.FC = () => {
 	const [selectedText, setSelectedText] = useState<string | null>(null);
-	const [responseText, setResponseText] = useState<string>("");
-	const [error, setError] = useState<string>("");
-	const [isloading, setIsloading] = useState<boolean>(false);
+	// const [responseText, setResponseText] = useState<string>("");
+	// const [error, setError] = useState<string>("");
+	// const [isloading, setIsloading] = useState<boolean>(false);
 
 	useEffect(() => {
 		const getHighlightedText = async () => {
@@ -22,71 +22,71 @@ const Home: React.FC = () => {
 					setSelectedText(response.data.text);
 				} else {
 					console.error("Error retrieving highlighted text:", response.message);
-					setError("Failed to retrieve highlighted text.");
+					// setError("Failed to retrieve highlighted text.");
 				}
 			} catch (err) {
 				console.error("Error in chrome.runtime.sendMessage:", err);
-				setError("An error occurred while fetching highlighted text.");
+				// setError("An error occurred while fetching highlighted text.");
 			}
 		};
 
 		getHighlightedText();
 	}, []);
 
-	useEffect(() => {
-		const fetchFlashCard = async () => {
-			if (selectedText && selectedText.trim() !== "") {
-				setIsloading(true);
-				try {
-					const customPrompt = `
-						Using the following text, create a flashcard with a clear and concise question and answer.
+	// useEffect(() => {
+	// 	const fetchFlashCard = async () => {
+	// 		if (selectedText && selectedText.trim() !== "") {
+	// 			setIsloading(true);
+	// 			try {
+	// 				const customPrompt = `
+	// 					Using the following text, create a flashcard with a clear and concise question and answer.
 
-						- **Format**:
-						- **Question**: A single, direct question that tests understanding of the key concept.
-						- **Answer**: A brief explanation or definition answering the question.
+	// 					- **Format**:
+	// 					- **Question**: A single, direct question that tests understanding of the key concept.
+	// 					- **Answer**: A brief explanation or definition answering the question.
 
-						Text:
-						"""${selectedText}"""
-						`;
-					const response = await api.post("/completions", {
-						messages: [
-							{
-								role: "user",
-								content: customPrompt,
-							},
-						],
-						model: "llama3-8b-8192",
-					});
-					const assistantMessage =
-						response.data.choices[0]?.message?.content || "";
-					setResponseText(assistantMessage);
-				} catch (err) {
-					if (axios.isAxiosError(err)) {
-						const axiosError = err as AxiosError;
-						console.error("Axios error:", axiosError.message);
-						setError(`API Error: ${axiosError.message}`);
-					} else {
-						console.error("Unexpected error:", err);
-						setError("An unexpected error occurred.");
-					}
-				} finally {
-					setIsloading(false);
-				}
-			}
-		};
-		fetchFlashCard();
-	}, [selectedText]);
+	// 					Text:
+	// 					"""${selectedText}"""
+	// 					`;
+	// 				const response = await api.post("/completions", {
+	// 					messages: [
+	// 						{
+	// 							role: "user",
+	// 							content: customPrompt,
+	// 						},
+	// 					],
+	// 					model: "llama3-8b-8192",
+	// 				});
+	// 				const assistantMessage =
+	// 					response.data.choices[0]?.message?.content || "";
+	// 				setResponseText(assistantMessage);
+	// 			} catch (err) {
+	// 				if (axios.isAxiosError(err)) {
+	// 					const axiosError = err as AxiosError;
+	// 					console.error("Axios error:", axiosError.message);
+	// 					setError(`API Error: ${axiosError.message}`);
+	// 				} else {
+	// 					console.error("Unexpected error:", err);
+	// 					setError("An unexpected error occurred.");
+	// 				}
+	// 			} finally {
+	// 				setIsloading(false);
+	// 			}
+	// 		}
+	// 	};
+	// 	fetchFlashCard();
+	// }, [selectedText]);
 
 	// Fetch data from OpenAI API whenever selectedText changes
 
 	return (
 		<div className="flex flex-col">
 			<Folders />
-			{isloading && <p>Loading...</p>}
-			{error && !isloading && <p style={{ color: "red" }}>{error}</p>}
-			{!isloading && (
-				<EditablePreview initialText={responseText ? responseText : ""} />
-			)}
+			{/* {isloading && <p>Loading...</p>}
+			{error && !isloading && <p style={{ color: "red" }}>{error}</p>} */}
+			{/* {!isloading && ( */}
+			<EditablePreview initialText={selectedText ? selectedText : ""} />
+			{/* )} */}
 			<Tags />
 			<Button className="mt-2 text-white">Save</Button>
 		</div>

--- a/yank_extension/src/chrome-services/utils/content.ts
+++ b/yank_extension/src/chrome-services/utils/content.ts
@@ -12,6 +12,38 @@ interface HighlightedText {
 let highlightedText: HighlightedText | null = null;
 type ColorPickerElement = HTMLImageElement;
 
+chrome.storage.sync.get("isHighlighterEnabled", (result) => {
+	const isEnabled = result.isHighlighterEnabled;
+	if (isEnabled) {
+		enableHighlighter();
+	} else {
+		disableHighlighter();
+	}
+});
+
+// Listen for changes to the highlighter state
+chrome.storage.onChanged.addListener((changes, areaName) => {
+	if (areaName === "sync" && changes.isHighlighterEnabled) {
+		const newValue = changes.isHighlighterEnabled.newValue;
+		if (newValue) {
+			enableHighlighter();
+		} else {
+			disableHighlighter();
+		}
+	}
+});
+
+function enableHighlighter(): void {
+	document.addEventListener("mouseup", handleMouseUp);
+	console.log("Highlighter enabled");
+}
+
+function disableHighlighter(): void {
+	document.removeEventListener("mouseup", handleMouseUp);
+	hideColorPicker();
+	console.log("Highlighter disabled");
+}
+
 function createColorPicker(): ColorPickerElement {
 	const penIcon: ColorPickerElement = document.createElement("img");
 	const imagePath: string = chrome.runtime.getURL(HIGHLIGHTER_IMAGE_PATH);
@@ -98,13 +130,13 @@ function applyHighlight(): void {
 	}
 }
 
-document.addEventListener("mouseup", (e: MouseEvent) => {
+function handleMouseUp(e: MouseEvent): void {
 	const selection = window.getSelection();
 	if (selection && !selection.isCollapsed) {
 		const selectedText = selection.toString();
 		console.log("Selected text:", selectedText);
-		const getRange = selection.getRangeAt(0);
-		const rect = getRange.getBoundingClientRect();
+		const range = selection.getRangeAt(0);
+		const rect = range.getBoundingClientRect();
 		const adjustedRect = {
 			top: rect.top + window.scrollY,
 			left: rect.left + window.scrollX,
@@ -116,4 +148,24 @@ document.addEventListener("mouseup", (e: MouseEvent) => {
 		showColorPicker(adjustedRect.right, adjustedRect.top);
 		e.stopImmediatePropagation();
 	}
-});
+}
+
+// document.addEventListener("mouseup", (e: MouseEvent) => {
+// 	const selection = window.getSelection();
+// 	if (selection && !selection.isCollapsed) {
+// 		const selectedText = selection.toString();
+// 		console.log("Selected text:", selectedText);
+// 		const getRange = selection.getRangeAt(0);
+// 		const rect = getRange.getBoundingClientRect();
+// 		const adjustedRect = {
+// 			top: rect.top + window.scrollY,
+// 			left: rect.left + window.scrollX,
+// 			bottom: rect.bottom + window.scrollY,
+// 			right: rect.right + window.scrollX,
+// 			width: rect.width,
+// 			height: rect.height,
+// 		};
+// 		showColorPicker(adjustedRect.right, adjustedRect.top);
+// 		e.stopImmediatePropagation();
+// 	}
+// });

--- a/yank_extension/src/components/ui/switch.tsx
+++ b/yank_extension/src/components/ui/switch.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import * as SwitchPrimitives from "@radix-ui/react-switch";
+
+import { cn } from "@/lib/utils";
+
+const Switch = React.forwardRef<
+	React.ElementRef<typeof SwitchPrimitives.Root>,
+	React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+	<SwitchPrimitives.Root
+		className={cn(
+			"focus-visible:ring-ring focus-visible:ring-offset-background data-[state=checked]:bg-customGreen data-[state=unchecked]:bg-customRed peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+			className,
+		)}
+		{...props}
+		ref={ref}
+	>
+		<SwitchPrimitives.Thumb
+			className={cn(
+				"pointer-events-none block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
+			)}
+		/>
+	</SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export { Switch };

--- a/yank_extension/tailwind.config.js
+++ b/yank_extension/tailwind.config.js
@@ -20,6 +20,8 @@ module.exports = {
 				background: "#FCFAEE",
 				foreground: "#1F2937", // Dark color for text
 				border: "#E5E7EB", // Light border color
+				customRed: "#B8001F",
+				customGreen: "#00B800",
 			},
 			// Custom font family
 			fontFamily: {


### PR DESCRIPTION
## Description
This PR addresses issue #10, introducing a new feature that allows users to **toggle the highlighter and text extraction on or off when visiting a webpage.** This feature was added because the highlighter icon popping up constantly, even when not needed, can be quite disruptive during reading.

However, I’ve noticed that the extension’s content script is still running even when the extension is unpinned. This behavior should not occur and needs to be fixed. I've opened issue #16 to track this problem.

Additionally, there’s another issue where the highlighter icon remains visible even after text is deselected without applying a highlight. I’ve opened issue #17 to address this as well.

**Please note that this new toggle feature only controls the extension’s functionality when it is pinned.**


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tests
- [ ] Documentation update

## How Has This Been Tested/ How others can test?
I have tested the functionality by toggling the switch icon in the UI and verifying whether the highlighting and text extraction work as expected. In this PR, when the switch is enabled, the highlighting icon appears, selected text is successfully highlighted, and the text is correctly extracted. If the switch is off the vice vasa behavior occurs.

However, I am uncertain whether this behavior persists across multiple webpages or if the toggle state is maintained when navigating between different pages. Further testing is needed to confirm the persistence of the state across different web pages.
## Screenshots (if applicable):
<img width="432" alt="Screenshot 2024-10-15 at 4 51 57 PM" src="https://github.com/user-attachments/assets/24911253-df68-4735-a248-924a98278a18">
