### PR TITLE
ENG-TASK-73: Web app integration

### DIFF
--- a/yank_extension/src/Mycomponents/navigation.tsx
+++ b/yank_extension/src/Mycomponents/navigation.tsx
@@ -14,9 +14,17 @@ const Navigation: React.FC = () => {
 			toast.error("Error logging out");
 		}
 	};
+
+	const openWebApp = () => {
+		chrome.tabs.create({ url: "http://localhost:3000/" });
+	};
+
 	return (
 		<div className="absolute left-2 top-2 flex space-x-2">
-			<button className="flex items-center space-x-1 rounded p-1 font-mono font-medium transition hover:outline hover:outline-1 hover:outline-gray-300">
+			<button
+				className="flex items-center space-x-1 rounded p-1 font-mono font-medium transition hover:outline hover:outline-1 hover:outline-gray-300"
+				onClick={openWebApp}
+			>
 				<IoIosGlobe size={16} />
 				<span className="text-xs">Web App</span>
 			</button>

--- a/yank_extension/vite.config.ts
+++ b/yank_extension/vite.config.ts
@@ -14,6 +14,6 @@ export default defineConfig({
 		},
 	},
 	server: {
-		port: 3000,
+		port: 3001,
 	},
 });


### PR DESCRIPTION
## Description
This PR introduces a small feature to enable users to navigate to the web app from the extension. We just trigger the creation of a tab using chrome APIS. 

However, we are using a hardcoded `localhost:3000` url which is not just a placeholder. To ensure we do not have this in production I have created issue https://github.com/lewiskyron/Yank/issues/32 to ensure that this is not forgotten before the code is shipped to users.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tests (adding or updating tests)
- [ ] Documentation update

## Testing Instructions
I changed the extension to `localhost:3001` and run the web app on `localhost:3000`. On clicking the web app button I was redirected to the web app. Works as expected.

## Screenshots (if applicable)
If your changes include visual components, add screenshots showing the affected pages or elements.
