### PR TITLE
ENG-TASK-94: Spaced repetition rating buttons

### DIFF
--- a/yank_web_app/src/components/Flashcards/flashCardsDialog.tsx
+++ b/yank_web_app/src/components/Flashcards/flashCardsDialog.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { motion } from "motion/react";
 import confetti from "./confetti.json";
 import Lottie from "lottie-react";
+import { X, Flame, ThumbsUp, Zap } from "lucide-react";
 
 import {
 	Dialog,
@@ -124,6 +125,56 @@ export function FlashCardsDialog({
 									Answer: {currentFlashcard.answer}
 								</p>
 							</motion.div>
+						)}
+
+						{showAnswer && (
+							<div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+								<Button
+									onClick={handleNext}
+									variant="outline"
+									className="flex h-auto max-w-[120px] flex-col items-center gap-1 whitespace-normal break-words p-3 text-center"
+								>
+									<X className="h-5 w-5 text-red-500" />
+									<span className="font-medium">Didn't Know</span>
+									<span className="text-muted-foreground text-xs">
+										I didn't know it or got it wrong.
+									</span>
+								</Button>
+								<Button
+									onClick={handleNext}
+									variant="outline"
+									className="flex h-auto max-w-[120px] flex-col items-center gap-1 whitespace-normal break-words p-3 text-center"
+								>
+									<Flame className="h-5 w-5 text-orange-500" />
+									<span className="font-medium">Tricky</span>
+									<span className="text-muted-foreground text-xs">
+										I remembered, but it was really hard.
+									</span>
+								</Button>
+								<Button
+									onClick={handleNext}
+									variant="outline"
+									className="flex h-auto max-w-[120px] flex-col items-center gap-1 whitespace-normal break-words p-3 text-center"
+								>
+									<ThumbsUp className="h-5 w-5 text-green-500" />
+									<span className="font-medium">Got It</span>
+									<span className="text-muted-foreground text-xs">
+										I remembered with some effort.
+									</span>
+								</Button>
+
+								<Button
+									onClick={handleNext}
+									variant="outline"
+									className="flex h-auto max-w-[120px] flex-col items-center gap-1 whitespace-normal break-words p-3 text-center"
+								>
+									<Zap className="h-5 w-5 text-blue-500" />
+									<span className="font-medium">Too Easy</span>
+									<span className="text-muted-foreground text-xs">
+										I remembered it instantly!
+									</span>
+								</Button>
+							</div>
 						)}
 
 						<div className="flex gap-2">


### PR DESCRIPTION
## Description
This is the introduction to the third phase of the spaced repetition implementation. For the `FlashcardDialog` we now have buttons that we will then map to the card rating to determine after how long we should show the card again as well which phase(learning, review, mastered) the card is in. In this PR, we have not introduced any logic that handles the rating but rather only implemented the visual elements. 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tests (adding or updating tests)
- [ ] Documentation update

## Testing Instructions
No testing instructions needed.

## Screenshots (if applicable)
<img width="596" alt="Screenshot 2025-01-13 at 10 05 34 PM" src="https://github.com/user-attachments/assets/fbf078af-6261-4471-8827-05a7811fbbcf" />
