### PR TITLE
ENG-TASk-96: Practice/study modes

### DIFF
--- a/yank_web_app/src/components/Flashcards/flashCardsDialog.tsx
+++ b/yank_web_app/src/components/Flashcards/flashCardsDialog.tsx
@@ -11,6 +11,7 @@ import { X, Flame, ThumbsUp, Zap } from "lucide-react";
 import { rateFlashcard } from "@/api/supabase/fsrsAdapter";
 import { Grade, Rating } from "ts-fsrs";
 import { FlashcardDialogProps } from "@/types/flashcard.types";
+import { PracticeMode } from "@/types/flashcard.types";
 
 import {
 	Dialog,
@@ -25,6 +26,7 @@ export function FlashCardsDialog({
 	isOpen,
 	onOpenChange,
 	folderName,
+	practiceMode,
 }: FlashcardDialogProps) {
 	const [currentIndex, setCurrentIndex] = useState(0);
 	const [userAnswer, setUserAnswer] = useState("");
@@ -128,7 +130,7 @@ export function FlashCardsDialog({
 							</motion.div>
 						)}
 
-						{showAnswer && (
+						{showAnswer && practiceMode === PracticeMode.SPACED_REPETITION && (
 							<div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
 								<Button
 									onClick={() => handleRating(Rating.Again)}

--- a/yank_web_app/src/components/Flashcards/practiceButton.tsx
+++ b/yank_web_app/src/components/Flashcards/practiceButton.tsx
@@ -1,18 +1,45 @@
-import { ClipboardDocumentListIcon } from "@heroicons/react/24/outline";
+import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ClipboardList, ChevronDown } from "lucide-react";
+import { PracticeMode } from "@/types/flashcard.types";
 
 interface PracticeButtonProps {
 	folderId: number;
-	onClick: (folderId: number) => void;
+	onClick: (folderId: number, mode: PracticeMode) => Promise<void>;
 }
 
 export function PracticeButton({ folderId, onClick }: PracticeButtonProps) {
 	return (
-		<button
-			className="flex w-fit items-center space-x-2 rounded-md border border-gray-500 px-4 py-2 text-sm text-gray-400 transition hover:bg-gray-700"
-			onClick={() => onClick(folderId)}
-		>
-			<ClipboardDocumentListIcon className="h-4 w-4" />
-			<span className="font-medium text-gray-400">Practice</span>
-		</button>
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button
+					variant="ghost"
+					className="flex w-fit items-center space-x-2 rounded-md border border-gray-500 px-4 py-2 text-sm text-gray-400 transition hover:bg-gray-700"
+				>
+					<ClipboardList className="h-4 w-4" />
+					<span className="font-medium text-gray-400">Practice</span>
+					<ChevronDown className="ml-1 h-4 w-4" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end" className="w-[200px]">
+				<DropdownMenuItem
+					onClick={() => onClick(folderId, PracticeMode.SPACED_REPETITION)}
+					className="cursor-pointer"
+				>
+					Spaced Repetition
+				</DropdownMenuItem>
+				<DropdownMenuItem
+					onClick={() => onClick(folderId, PracticeMode.CHRONOLOGICAL)}
+					className="cursor-pointer"
+				>
+					Chronological
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
 }

--- a/yank_web_app/src/components/FoldersBox/columns.tsx
+++ b/yank_web_app/src/components/FoldersBox/columns.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { CreateFlashcardDialog } from "@/components/Flashcards/createFlashcardDialog";
 import { type User } from "@supabase/supabase-js";
 import { TransformedFlashcard } from "@/types/flashcard.types";
+import { PracticeMode } from "@/types/flashcard.types";
 
 export type Folder = {
 	folder_name: string;
@@ -47,10 +48,14 @@ export const columns = (
 			const [flashcards, setFlashcards] = useState<TransformedFlashcard[]>([]);
 			const [isDialogOpen, setIsDialogOpen] = useState(false);
 			const [error, setError] = useState<string | null>(null);
+			const [selectedMode, setSelectedMode] = useState<PracticeMode>(
+				PracticeMode.SPACED_REPETITION,
+			);
 
-			const handlePracticeClick = async (id: number) => {
+			const handlePracticeClick = async (id: number, mode: PracticeMode) => {
 				setError(null);
-				const { data, error } = await fetchFlashcards(id, true);
+				setSelectedMode(mode);
+				const { data, error } = await fetchFlashcards(id, mode);
 
 				if (error) {
 					setError("Failed to fetch flashcards.");
@@ -70,6 +75,7 @@ export const columns = (
 						isOpen={isDialogOpen}
 						onOpenChange={setIsDialogOpen}
 						folderName={folderName}
+						practiceMode={selectedMode}
 					/>
 				</div>
 			);

--- a/yank_web_app/src/types/flashcard.types.ts
+++ b/yank_web_app/src/types/flashcard.types.ts
@@ -22,9 +22,15 @@ export interface FlashcardDialogProps {
 	isOpen: boolean;
 	onOpenChange: (open: boolean) => void;
 	folderName: string;
+	practiceMode: PracticeMode;
 }
 
 export interface RatingResponse {
 	success: boolean;
 	error?: string;
+}
+
+export enum PracticeMode {
+	SPACED_REPETITION = "spaced_repetition",
+	CHRONOLOGICAL = "chronological",
 }


### PR DESCRIPTION
## Description
### Overview
Added a new practice mode feature that allows users to study flashcards in two different ways:
- **Spaced Repetition:** Shows due cards and includes rating buttons for FSRS algorithm
- **Chronological:** Shows all cards sorted by creation date (newest first) without rating options

### Technical Changes
1. Added `PracticeMode` enum to distinguish between study modes
2. Modified `fetchFlashcards` function to support different sorting/filtering based on mode:
          - Spaced Repetition: Filters for due cards using FSRS
          - Chronological: Sorts by created_at timestamp

On the UI Side, I updated `PracticeButton` to include a dropdown menu for mode selection. Additionally, modified `FlashCardsDialog` to conditionally render rating buttons based on selected mode. Finally, added mode tracking in the practice cell component to maintain selected mode state

### User Impact
Users can now:
- Choose between two study methods from a dropdown menu
- Review cards using spaced repetition for optimal learning
- Browse all cards chronologically to see recently added content
- See rating options only in spaced repetition mode

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tests (adding or updating tests)
- [ ] Documentation update

## Testing Instructions
Tested this and ensure the conditional rendering of both modes worked as well as the previous spaced repetition functionality. As expected in spaced repetition  mode, less Flashcards are fetched from the back-end since some are not due yet.

## Screenshots (if applicable)
<img width="1178" alt="Screenshot 2025-01-17 at 5 14 52 PM" src="https://github.com/user-attachments/assets/0437d58f-7254-4ceb-9966-a7d7c5e20af1" />

